### PR TITLE
Escaped double quotes on JSON Output

### DIFF
--- a/js/DataGridRenderer.js
+++ b/js/DataGridRenderer.js
@@ -141,7 +141,7 @@ var DataGridRenderer = {
         if ((headerTypes[j] == "int")||(headerTypes[j] == "float")) {
           var rowOutput = row[j] || "null";
         } else {
-          var rowOutput = '"' + ( row[j] || "" ) + '"';
+          var rowOutput = '"' + ( row[j].replace(/\"/g,"\\\"") || "" ) + '"';
         };
   
       outputText += ('"'+headerNames[j] +'"' + ":" + rowOutput );


### PR DESCRIPTION
This generates valid JSON with pasting the following:

```
title
"text ""text"" text"
```

generating:

```
[{"title":"text \"text\" text"}]
```

instead of:

```
[{"title":"text "text" text"}]
```
