### PR TITLE
Adds "Row Arrays, Text" output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-## DESCRIPTION
+## Captain Javascript
+
+This is a fork of https://github.com/shancarter/Mr-Data-Converter
 
 Takes CSV or tab-delimited data from Excel and converts it into several web-friendly formats, include JSON and XML.
-View it in action here: http://shancarter.github.com/mr-data-converter/
+
+Features of Captain Javascript over Mr Data Converter:
+
+* New output type: JSON - Text Row Array. This is useful for quickly creating clean JS arrays from Google Spreadsheets data. It tries to be more sensible with data type detection, and won't populate an array with blank entries; it also entirely ignores blank lines.
+* Tweaked defaults to be a little "safer" by default

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a fork of https://github.com/shancarter/Mr-Data-Converter
 
-You can try it out right now at http://cr3ative.github.io/mr-data-converter/
+You can try it out right now at http://cr3ative.github.io/captain-javascript/
 
 Takes CSV or tab-delimited data from Excel and converts it into several web-friendly formats, include JSON and XML.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is a fork of https://github.com/shancarter/Mr-Data-Converter
 
+You can try it out right now at http://cr3ative.github.io/mr-data-converter/
+
 Takes CSV or tab-delimited data from Excel and converts it into several web-friendly formats, include JSON and XML.
 
 Features of Captain Javascript over Mr Data Converter:

--- a/index.html
+++ b/index.html
@@ -4,9 +4,8 @@
 <html lang="en">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-  <title>Mr. Data Converter</title>
-  <meta name="author" content="Shan Carter">
-  <!-- Date: 2010-08-26 -->
+  <title>Captain Javascript</title>
+  
   <link rel="stylesheet" href="css/converter.css" type="text/css" media="screen" title="no title" charset="utf-8">
 
   <script src="js/jquery.js" type="text/javascript" charset="utf-8"></script>
@@ -20,25 +19,24 @@
   <div id='base'>
     <div id='header'>
       <div id="description">
-        <h1>Mr. Data Converter</h1>
+        <h1>Captain Javascript</h1>
         <p>I will convert your Excel data into one of several web-friendly formats, including HTML, JSON and XML.</p>
-        <p>Fork me on <a href="http://github.com/shancarter/Mr-Data-Converter">github</a>.</p>
       </div>
       <div id='settings'>
         <h3>Settings</h3>
         <form id='settingsForm'>
            <p>Delimiter:
 
-             <label><input class="settingsElement" type="radio" name="delimiter" id='delimiterAuto'   value="auto" checked/> Auto</label>
+             <label><input class="settingsElement" type="radio" name="delimiter" id='delimiterAuto'   value="auto" /> Auto</label>
              <label><input class="settingsElement" type="radio" name="delimiter" id='delimiterComma'  value="comma" /> Comma</label>
-             <label><input class="settingsElement" type="radio" name="delimiter" id='delimiterTab'    value="tab" /> Tab</label>
+             <label><input class="settingsElement" type="radio" name="delimiter" id='delimiterTab'    value="tab" checked/> Tab</label>
             </p>
           <p>Decimal Sign:
 
              <label><input class="settingsElement" type="radio" name="decimal" id='decimalDot'   value="dot" checked/> Dot</label>
              <label><input class="settingsElement" type="radio" name="decimal" id='decimalComma'  value="comma" /> Comma</label>
             </p>
-          <p><label><input class="settingsElement" type="checkbox" name="" value="" id="headersProvidedCB" checked /> First row is the header</label></p>
+          <p><label><input class="settingsElement" type="checkbox" name="" value="" id="headersProvidedCB" /> First row is the header</label></p>
           <div class="settingsGroup">
             <p>Transform: <label><input class="settingsElement" type="radio" name="headerModifications" value="downcase" id='headersDowncase' /> downcase</label>
             <label><input class="settingsElement" type="radio" name="headerModifications" id='headersUpcase' value="upcase" /> upcase</label>
@@ -47,7 +45,7 @@
 
           <p><label><input class="settingsElement" type="checkbox" name="some_name" value="" id="includeWhiteSpaceCB" checked /> Include white space in output</label></p>
           <div class="settingsGroup">
-            <p>Indent with: <label><input class="settingsElement" type="radio" name="indentType" value="tabs" id='includeWhiteSpaceTabs'/> tabs</label> <label><input class="settingsElement" type="radio" name="indentType" value="spaces" id='includeWhiteSpaceSpaces' checked/> spaces</label></p>
+            <p>Indent with: <label><input class="settingsElement" type="radio" name="indentType" value="tabs" id='includeWhiteSpaceTabs' checked/> tabs</label> <label><input class="settingsElement" type="radio" name="indentType" value="spaces" id='includeWhiteSpaceSpaces' /> spaces</label></p>
           </div>
 
 

--- a/js/CSVParser.js
+++ b/js/CSVParser.js
@@ -56,7 +56,6 @@ var CSVParser = {
       columnDelimiter = "\t"
     }
 
-
     // kill extra empty lines
     RE = new RegExp("^" + rowDelimiter + "+", "gi");
     input = input.replace(RE, "");
@@ -69,7 +68,6 @@ var CSVParser = {
     //   dataArray.push(arr[i].split(columnDelimiter));
     // };
 
-
     // dataArray = jQuery.csv(columnDelimiter)(input);
     dataArray = this.CSVToArray(input, columnDelimiter);
 
@@ -81,7 +79,6 @@ var CSVParser = {
         dataArray[i][j] = dataArray[i][j].replace("\r", "\\r");
       };
     };
-
 
     var headerNames = [];
     var headerTypes = [];
@@ -209,15 +206,11 @@ var CSVParser = {
           // Delimiters.
           "(\\" + strDelimiter + "|\\r?\\n|\\r|^)" +
 
-          // Quoted fields.
-          "(?:\"([^\"]*(?:\"\"[^\"]*)*)\"|" +
-
           // Standard fields.
-          "([^\"\\" + strDelimiter + "\\r\\n]*))"
+          "([^\\" + strDelimiter + "\\r\\n]*)"
         ),
         "gi"
         );
-
 
       // Create an array to hold our data. Give the array
       // a default empty first row.
@@ -226,7 +219,6 @@ var CSVParser = {
       // Create an array to hold our individual pattern
       // matching groups.
       var arrMatches = null;
-
 
       // Keep looping over the regular expression matches
       // until we can no longer find a match.
@@ -250,15 +242,17 @@ var CSVParser = {
 
         }
 
-
         // Now that we have our delimiter out of the way,
         // let's check to see which kind of value we
         // captured (quoted or unquoted).
         if (arrMatches[ 2 ]){
 
+        	// Uh, escape quotes
+        	var strMatchedValue = arrMatches[ 2 ].replace(/"/g, '\\"');
+
           // We found a quoted value. When we capture
           // this value, unescape any double quotes.
-          var strMatchedValue = arrMatches[ 2 ].replace(
+          strMatchedValue = strMatchedValue.replace(
             new RegExp( "\"\"", "g" ),
             "\""
             );
@@ -270,10 +264,10 @@ var CSVParser = {
 
         }
 
-
         // Now that we have our value string, let's add
         // it to the data array.
         arrData[ arrData.length - 1 ].push( strMatchedValue );
+
       }
 
       // Return the parsed data.

--- a/js/CSVParser.js
+++ b/js/CSVParser.js
@@ -74,9 +74,11 @@ var CSVParser = {
     //escape out any tabs or returns or new lines
     for (var i = dataArray.length - 1; i >= 0; i--){
       for (var j = dataArray[i].length - 1; j >= 0; j--){
-        dataArray[i][j] = dataArray[i][j].replace("\t", "\\t");
-        dataArray[i][j] = dataArray[i][j].replace("\n", "\\n");
-        dataArray[i][j] = dataArray[i][j].replace("\r", "\\r");
+      	if (typeof dataArray[i][j] !== "undefined") {
+	        dataArray[i][j] = dataArray[i][j].replace("\t", "\\t");
+	        dataArray[i][j] = dataArray[i][j].replace("\n", "\\n");
+	        dataArray[i][j] = dataArray[i][j].replace("\r", "\\r");
+        }
       };
     };
 
@@ -115,7 +117,7 @@ var CSVParser = {
     //test all the rows for proper number of columns.
     for (var i=0; i < dataArray.length; i++) {
       var numValues = dataArray[i].length;
-      if (numValues != numColumns) {this.log("Error parsing row "+String(i)+". Wrong number of columns.")};
+      if (numValues != numColumns) {this.log("Error parsing row "+String(i)+". Wrong number of columns. " + dataArray[i])};
     };
 
     //test columns for number data type

--- a/js/DataGridRenderer.js
+++ b/js/DataGridRenderer.js
@@ -141,10 +141,10 @@ var DataGridRenderer = {
         if ((headerTypes[j] == "int")||(headerTypes[j] == "float")) {
           var rowOutput = row[j] || "null";
         } else {
-          var rowOutput = '"' + ( row[j] || "" ) + '"';
+          var rowOutput = '"' + ( row[j].trim() || "" ) + '"';
         };
   
-      outputText += ('"'+headerNames[j] +'"' + ":" + rowOutput );
+      outputText += ('"'+headerNames[j].trim() +'"' + ":" + rowOutput );
   
         if (j < (numColumns-1)) {outputText+=","};
       };
@@ -213,7 +213,7 @@ var DataGridRenderer = {
       for (var j=0; j < numColumns; j++) {
       	if (dataGrid[i][j]) {
 		    	if (dataGrid[i][j].length > 0) {
-		        build.push('"'+ (dataGrid[i][j] || "")+'"');
+		        build.push('"'+ (dataGrid[i][j].trim() || "")+'"');
 		    	}
       	}
       };

--- a/js/DataGridRenderer.js
+++ b/js/DataGridRenderer.js
@@ -188,6 +188,37 @@ var DataGridRenderer = {
     return outputText;
   },
   
+
+  //---------------------------------------
+  // JSON - Text Row Array
+  //---------------------------------------
+  jsonArrayRowsText: function (dataGrid, headerNames, headerTypes, indent, newLine) {
+    //inits...
+    var commentLine = "//";
+    var commentLineEnd = "";
+    var outputText = "";
+    var numRows = dataGrid.length;
+    var numColumns = headerNames.length;
+    
+    //begin render loop
+    outputText += "["+newLine;
+    for (var i=0; i < numRows; i++) {
+      outputText += indent+"[";
+      var build = [];
+      for (var j=0; j < numColumns; j++) {
+      	if (dataGrid[i][j].length > 0) {
+          build.push('"'+ (dataGrid[i][j] || "")+'"');
+      	}
+      };
+      outputText += build.join(",");
+      outputText += "]";
+      if (i < (numRows-1)) {outputText += ","+ newLine};
+    };
+    outputText += newLine+"]";
+    
+    
+    return outputText;
+  },
   
   //---------------------------------------
   // JSON Array of Rows

--- a/js/DataGridRenderer.js
+++ b/js/DataGridRenderer.js
@@ -141,7 +141,8 @@ var DataGridRenderer = {
         if ((headerTypes[j] == "int")||(headerTypes[j] == "float")) {
           var rowOutput = row[j] || "null";
         } else {
-          var rowOutput = '"' + ( row[j].trim() || "" ) + '"';
+          if (row[j]) { row[j] = row[j].trim(); }
+          var rowOutput = '"' + ( row[j] || "" ) + '"';
         };
   
       outputText += ('"'+headerNames[j].trim() +'"' + ":" + rowOutput );

--- a/js/DataGridRenderer.js
+++ b/js/DataGridRenderer.js
@@ -206,8 +206,10 @@ var DataGridRenderer = {
       outputText += indent+"[";
       var build = [];
       for (var j=0; j < numColumns; j++) {
-      	if (dataGrid[i][j].length > 0) {
-          build.push('"'+ (dataGrid[i][j] || "")+'"');
+      	if (dataGrid[i][j]) {
+		    	if (dataGrid[i][j].length > 0) {
+		        build.push('"'+ (dataGrid[i][j] || "")+'"');
+		    	}
       	}
       };
       outputText += build.join(",");

--- a/js/DataGridRenderer.js
+++ b/js/DataGridRenderer.js
@@ -202,8 +202,13 @@ var DataGridRenderer = {
     
     //begin render loop
     outputText += "["+newLine;
+
     for (var i=0; i < numRows; i++) {
-      outputText += indent+"[";
+
+    	var thisRow = "";
+    
+      thisRow += indent+"[";
+    
       var build = [];
       for (var j=0; j < numColumns; j++) {
       	if (dataGrid[i][j]) {
@@ -212,10 +217,19 @@ var DataGridRenderer = {
 		    	}
       	}
       };
-      outputText += build.join(",");
-      outputText += "]";
-      if (i < (numRows-1)) {outputText += ","+ newLine};
+      thisRow += build.join(",");
+      thisRow += "]";
+    
+      if (i < (numRows-1)) {thisRow += ","+ newLine};
+
+      if (thisRow == indent + "[]") {
+      	outputText = outputText.substring(0,(outputText.length-2));
+      } else if (thisRow !== indent + "[]," + newLine) {
+      	outputText += thisRow;
+      }
+    
     };
+    
     outputText += newLine+"]";
     
     

--- a/js/converter.js
+++ b/js/converter.js
@@ -23,6 +23,7 @@ function DataConverter(nodeId) {
                                 {"text":"JSON - Properties",      "id":"json",             "notes":""},
                                 {"text":"JSON - Column Arrays",   "id":"jsonArrayCols",    "notes":""},
                                 {"text":"JSON - Row Arrays",      "id":"jsonArrayRows",    "notes":""},
+                                {"text":"JSON - Row Arrays, Text",      "id":"jsonArrayRowsText",    "notes":""},
                                 {"text":"JSON - Dictionary",      "id":"jsonDict",         "notes":""},
                                 {"text":"MySQL",                  "id":"mysql",            "notes":""},
                                 {"text":"PHP",                    "id":"php",              "notes":""},

--- a/js/converter.js
+++ b/js/converter.js
@@ -32,7 +32,7 @@ function DataConverter(nodeId) {
                                 {"text":"XML - Properties",       "id":"xmlProperties",    "notes":""},
                                 {"text":"XML - Nodes",            "id":"xml",              "notes":""},
                                 {"text":"XML - Illustrator",      "id":"xmlIllustrator",   "notes":""}];
-  this.outputDataType         = "json";
+  this.outputDataType         = "jsonArrayRowsText";
 
   this.columnDelimiter        = "\t";
   this.rowDelimiter           = "\n";


### PR DESCRIPTION
For this spreadsheet: https://docs.google.com/spreadsheets/d/1CQRqa4h6X-WjNWzyL3Tkaa5u7A_JNrOLZ_TLNtRSRRw/edit?usp=sharing

Pasting it in with "Row Arrays" would generate rows like this:

```
 ["Cambodia","Kingdom of Cambodia",0,0,0,0],
```

And like this:

```
 ["East Timor","Democratic Republic of Timor-Leste",Timor-Leste,Timor L'est,0,0],
```

Note the zeroes where there don't need to be there, and "Timor-Leste" not being in quotation marks.

Therefore the "Row Arrays, Text" option completely steamrollers out the integer detection which might have been failing, and also discards empty cells. It's quite opinionated so I made it a new output filter rather than playing around with "Row Arrays". 

Hope this helps, please do ask if I can help make this clearer!
