### PR TITLE
Add checkbox setting for JSON-Dictionary to include the first key:value in each object

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,9 @@
           <div class="settingsGroup">
             <p>Indent with: <label><input class="settingsElement" type="radio" name="indentType" value="tabs" id='includeWhiteSpaceTabs'/> tabs</label> <label><input class="settingsElement" type="radio" name="indentType" value="spaces" id='includeWhiteSpaceSpaces' checked/> spaces</label></p>
           </div>
+          <p>
+            <label><input class="settingsElement" type="checkbox" name="keyDictionary" value="" id="includeKeyInDictionary" unchecked /> Include id/key object in JSON dictionary</label>
+          </p>
 
 
         </form>

--- a/js/Controller.js
+++ b/js/Controller.js
@@ -32,6 +32,8 @@ $(document).ready(function(){
       _gaq.push(['_trackEvent', 'Settings',evt.currentTarget.id ]);
     };
 
+    d.includeKeyInDictionary = $('#includeKeyInDictionary').attr('checked');
+
     d.includeWhiteSpace = $('#includeWhiteSpaceCB').attr('checked');
     
     if (d.includeWhiteSpace) {

--- a/js/DataGridRenderer.js
+++ b/js/DataGridRenderer.js
@@ -226,13 +226,17 @@ var DataGridRenderer = {
   //---------------------------------------
   // JSON Dictionary
   //---------------------------------------
-  jsonDict: function(dataGrid, headerNames, headerTypes, indent, newLine) {
+  jsonDict: function(dataGrid, headerNames, headerTypes, indent, newLine, includeKeyInDictionary) {
     //inits...
     var commentLine = "//";
     var commentLineEnd = "";
     var outputText = "";
     var numRows = dataGrid.length;
     var numColumns = headerNames.length;
+    var initialJ = 1;
+    if (includeKeyInDictionary) {
+        initialJ = 0;
+    }
 
     //begin render loop
     outputText += "{" + newLine;
@@ -242,8 +246,8 @@ var DataGridRenderer = {
         outputText += _fmtVal(i, 1, dataGrid);
       } else {
         outputText += '{ ';
-        for (var j = 1; j < numColumns; j++) {
-          if (j > 1) outputText += ', ';
+        for (var j = initialJ; j < numColumns; j++) {
+          if (j > initialJ) outputText += ', ';
           outputText += '"' + headerNames[j] + '"' + ":" + _fmtVal(i, j, dataGrid);
         }
         outputText += '}';

--- a/js/converter.js
+++ b/js/converter.js
@@ -60,6 +60,8 @@ function DataConverter(nodeId) {
   this.includeWhiteSpace      = true;
   this.useTabsForIndent       = false;
 
+  this.includeKeyInDictionary = false;
+
 }
 
 //---------------------------------------
@@ -160,7 +162,7 @@ DataConverter.prototype.convert = function() {
     var headerTypes = parseOutput.headerTypes;
     var errors = parseOutput.errors;
 
-    this.outputText = DataGridRenderer[this.outputDataType](dataGrid, headerNames, headerTypes, this.indent, this.newLine);
+    this.outputText = DataGridRenderer[this.outputDataType](dataGrid, headerNames, headerTypes, this.indent, this.newLine, this.includeKeyInDictionary);
 
 
     this.outputTextArea.val(errors + this.outputText);


### PR DESCRIPTION
Add checkbox setting for JSON-Dictionary to have the key:value of the first column be included in the dictionary object (in addition to the value being used as the key for the whole row).

An example of this being useful is if your first column in your spreadsheet is an id field and you want the id to be included in each object in the JSON dictionary.
