### PR TITLE
Adding new output type - Javascript Object

### DIFF
--- a/js/DataGridRenderer.js
+++ b/js/DataGridRenderer.js
@@ -120,6 +120,41 @@ var DataGridRenderer = {
     return outputText;
   },
   
+   //---------------------------------------
+  // Javascript Object
+  //---------------------------------------
+  
+  json: function (dataGrid, headerNames, headerTypes, indent, newLine) {
+    //inits...
+    var commentLine = "//";
+    var commentLineEnd = "";
+    var outputText = "var mrDataConverterObj = JSON.parse('[";
+    var numRows = dataGrid.length;
+    var numColumns = headerNames.length;
+    
+    //begin render loop
+    for (var i=0; i < numRows; i++) {
+      var row = dataGrid[i];
+      outputText += "{";
+      for (var j=0; j < numColumns; j++) {
+        if ((headerTypes[j] == "int")||(headerTypes[j] == "float")) {
+          var rowOutput = row[j] || "null";
+        } else {
+          var rowOutput = '"' + ( row[j] || "" ) + '"';
+        };
+  
+      outputText += ('"'+headerNames[j] +'"' + ":" + rowOutput );
+  
+        if (j < (numColumns-1)) {outputText+=","};
+      };
+      outputText += "}";
+      if (i < (numRows-1)) {outputText += ","};
+    };
+    outputText += "]');";
+    
+    return outputText;
+  },
+  
   
   //---------------------------------------
   // JSON properties

--- a/js/DataGridRenderer.js
+++ b/js/DataGridRenderer.js
@@ -124,7 +124,7 @@ var DataGridRenderer = {
   // Javascript Object
   //---------------------------------------
   
-  json: function (dataGrid, headerNames, headerTypes, indent, newLine) {
+  javascript: function (dataGrid, headerNames, headerTypes, indent, newLine) {
     //inits...
     var commentLine = "//";
     var commentLineEnd = "";


### PR DESCRIPTION
I love the fact that the MySQL output can be pasted into SQL editor. I needed the same thing for pasting into Javascript editor when dealing with really large spreadsheets. These changes will allow users to paste the data output straight into their Javascript editor; providing all of the benefits of working with a native Javascript object (and all of its properties).
The code changes in this commit are simply the addition of native instantiation of a Javascript object named mrDataConverterObj, the removal of the newline character (after each record) and enclosing the entire output with single quotes (as you would do if you wanted to parse the output as a JSON object in Javascript).